### PR TITLE
Add betterCombos folder support for LoadLatent_I2V_MXD

### DIFF
--- a/web/js/betterCombos.js
+++ b/web/js/betterCombos.js
@@ -6,6 +6,7 @@ import { api } from "../../../scripts/api.js";
 const CHECKPOINT_LOADER = "CheckpointLoader|pysssss";
 const LORA_LOADER = "LoraLoader|pysssss";
 const LOAD_LATENT_WITH_PARAMS = "LoadLatent_WithParams";
+const LOAD_LATENT_I2V_MXD = "LoadLatent_I2V_MXD";
 const IMAGE_WIDTH = 384;
 const IMAGE_HEIGHT = 384;
 
@@ -13,6 +14,7 @@ const NODE_CONFIGS = {
         [CHECKPOINT_LOADER]: { type: "checkpoints", widgetName: "ckpt_name", hasImages: true },
         [LORA_LOADER]: { type: "loras", widgetName: "lora_name", hasImages: true },
         [LOAD_LATENT_WITH_PARAMS]: { type: "latents", widgetName: "latent", hasImages: false },
+        [LOAD_LATENT_I2V_MXD]: { type: "latents", widgetName: "latent", hasImages: false },
 };
 
 const CONFIG_BY_TYPE = Object.fromEntries(


### PR DESCRIPTION
## Summary
- extend betterCombos node configuration to recognise the LoadLatent_I2V_MXD node
- reuse the existing latent folder dropdown behaviour for the I2V loader widget

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e432505e1883319a837813b4c0d056